### PR TITLE
Rename fileName -> file for logback xml compatibility

### DIFF
--- a/src/main/java/com/esri/logger/appender/RollingFileAppender.kt
+++ b/src/main/java/com/esri/logger/appender/RollingFileAppender.kt
@@ -32,7 +32,7 @@ class RollingFileAppender : Appender {
 
   override var encoder: Encoder? = null
 
-  @JvmField var fileName: String = FILENAME_DEFAULT
+  @JvmField var file: String = FILENAME_DEFAULT
 
   private val bufferedWriter: BufferedWriter by lazy {
     val appDir = AndroidAPIProvider.filesDir
@@ -41,9 +41,9 @@ class RollingFileAppender : Appender {
       logDir.mkdir()
     }
 
-    logDir.rotateFilesInPath(fileName, EXTENSION, MAX_FILES)
+    logDir.rotateFilesInPath(file, EXTENSION, MAX_FILES)
 
-    val logFile = File("${logDir}/$fileName$EXTENSION")
+    val logFile = File("${logDir}/$file$EXTENSION")
     logFile.createNewFile()
     BufferedWriter(FileWriter(logFile))
   }

--- a/src/test/java/com/esri/logger/ConfigurationParserTest.kt
+++ b/src/test/java/com/esri/logger/ConfigurationParserTest.kt
@@ -179,7 +179,7 @@ class ConfigurationParserTest {
         """
             <configuration>
                 <appender name="file" class="com.esri.logger.appender.RollingFileAppender">
-                    <fileName>sample</fileName>
+                    <file>sample</file>
                     <encoder>
                         <pattern>arbitrary pattern</pattern>
                     </encoder>
@@ -200,6 +200,6 @@ class ConfigurationParserTest {
     assertThat("A RollingFileAppender should be added", appender is RollingFileAppender)
     assertThat(
         "File appender should have filename set",
-        (appender as RollingFileAppender).fileName == "sample")
+        (appender as RollingFileAppender).file == "sample")
   }
 }


### PR DESCRIPTION
This way we can validate our xml config using the same schema as logback-android.