### PR TITLE
Fix unit test

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,16 @@ android {
   testOptions { unitTests { isIncludeAndroidResources = true } }
 }
 
+tasks.withType<Test> {
+  testLogging {
+    events("passed", "skipped", "failed", "standardOut", "standardError")
+    exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+    showCauses = true
+    showExceptions = true
+    showStackTraces = true
+  }
+}
+
 dependencies {
   implementation(libs.androidx.core.ktx)
   implementation(libs.androidx.appcompat)

--- a/src/test/java/com/esri/logger/PatternEncoderTest.kt
+++ b/src/test/java/com/esri/logger/PatternEncoderTest.kt
@@ -15,12 +15,19 @@
 package com.esri.logger
 
 import com.esri.logger.encoder.PatternEncoder
+import java.util.TimeZone
 import org.junit.Assert.*
+import org.junit.Before
 import org.junit.Test
 import org.slf4j.event.Level
 import org.slf4j.helpers.BasicMarkerFactory
 
 class PatternEncoderTest {
+@Before
+  fun setUp() {
+      TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"))
+  }
+
   @Test
   fun encoder_encodesSimpleMessage() {
     val expectedMessage = "Simple message"


### PR DESCRIPTION
Explicitly set the timezone in the unit tests (so that we know what output to expect and can test for it).