### PR TITLE
Implement NOP MDC adapter

### DIFF
--- a/src/main/java/com/esri/logger/khronicle/ServiceProvider.kt
+++ b/src/main/java/com/esri/logger/khronicle/ServiceProvider.kt
@@ -17,12 +17,14 @@ package com.esri.logger.khronicle
 import org.slf4j.ILoggerFactory
 import org.slf4j.IMarkerFactory
 import org.slf4j.helpers.BasicMarkerFactory
+import org.slf4j.helpers.NOPMDCAdapter
 import org.slf4j.spi.MDCAdapter
 import org.slf4j.spi.SLF4JServiceProvider
 
 class ServiceProvider : SLF4JServiceProvider {
   private val loggerFactory = LoggerFactory()
   private val markerFactory = BasicMarkerFactory()
+  private val mdcAdapter = NOPMDCAdapter()
 
   override fun getLoggerFactory(): ILoggerFactory {
     return loggerFactory
@@ -33,7 +35,7 @@ class ServiceProvider : SLF4JServiceProvider {
   }
 
   override fun getMDCAdapter(): MDCAdapter {
-    TODO("Not yet implemented")
+    return mdcAdapter
   }
 
   override fun getRequestedApiVersion(): String {


### PR DESCRIPTION
With the latest version of SLF4J (2.0.17), `getMDCAdapter` will be called an it will result in Khronicle throwing an exception (`NotImplementedError`).

Fortunately SLF4J provides a `NOPMDCAdapter` exactly for this case 😇.