### PR TITLE
fix: handle empty varargs

### DIFF
--- a/src/main/java/com/esri/logger/khronicle/LoggerImpl.kt
+++ b/src/main/java/com/esri/logger/khronicle/LoggerImpl.kt
@@ -43,7 +43,7 @@ class LoggerImpl(private val loggerName: String) : Logger {
     if (level > logLevel) return
 
     val internalThrowable =
-        if (throwable == null && arguments?.last() is Throwable) {
+        if (throwable == null && arguments?.lastOrNull() is Throwable) {
           val lastThrowable = (arguments.last() as Throwable)
           arguments.removeAt(arguments.lastIndex)
           lastThrowable

--- a/src/test/java/com/esri/logger/khronicle/LoggerImplTest.kt
+++ b/src/test/java/com/esri/logger/khronicle/LoggerImplTest.kt
@@ -90,6 +90,52 @@ class LoggerImplTest {
   }
 
   @Test
+  fun logger_handlesEmptyVarargArguments() {
+    val logger = LoggerImpl("testLogger")
+    val testMessage = "Hello, test"
+    val events = mutableListOf<org.slf4j.event.LoggingEvent>()
+    val appender = TestAppender()
+    appender.output = { event -> events.add(event) }
+    logger.appenders.add(appender)
+
+    logger.trace(testMessage, *emptyArray())
+    logger.debug(testMessage, *emptyArray())
+    logger.info(testMessage, *emptyArray())
+    logger.warn(testMessage, *emptyArray())
+    logger.error(testMessage, *emptyArray())
+
+    assertEquals("Each log level should append one event", 5, events.size)
+    events.forEach { event ->
+      assertEquals("Message should be passed to appender", testMessage, event.message)
+      assertTrue("Arguments should be empty", event.arguments.isEmpty())
+    }
+  }
+
+  @Test
+  fun logger_handlesEmptyVarargArguments_andAMarker() {
+    val marker = MarkerFactory.getMarker("marker")
+    val logger = LoggerImpl("testLogger")
+    val testMessage = "Hello, test"
+    val events = mutableListOf<org.slf4j.event.LoggingEvent>()
+    val appender = TestAppender()
+    appender.output = { event -> events.add(event) }
+    logger.appenders.add(appender)
+
+    logger.trace(marker, testMessage, *emptyArray())
+    logger.debug(marker, testMessage, *emptyArray())
+    logger.info(marker, testMessage, *emptyArray())
+    logger.warn(marker, testMessage, *emptyArray())
+    logger.error(marker, testMessage, *emptyArray())
+
+    assertEquals("Each log level should append one event", 5, events.size)
+    events.forEach { event ->
+      assertEquals("Message should be passed to appender", testMessage, event.message)
+      assertTrue("Arguments should be empty", event.arguments.isEmpty())
+      assertTrue("Marker should be passed to the appender", event.markers.contains(marker))
+    }
+  }
+
+  @Test
   fun logger_handlesOneArgument() {
     val expectedArgument = "argument"
     val logger = LoggerImpl("testLogger")


### PR DESCRIPTION
Khronicle currently handles a non-empty and null for `arguments`, but crashes if `arguments` is empty. This treats the empty `arguments` just the same.

Currently it crashes:

```
java.util.NoSuchElementException: List is empty.
        at kotlin.collections.CollectionsKt___CollectionsKt.last(_Collections.kt:428)
        at com.esri.logger.khronicle.LoggerImpl.log(LoggerImpl.kt:46)
        at com.esri.logger.khronicle.LoggerImpl.log$default(LoggerImpl.kt:35)
        at com.esri.logger.khronicle.LoggerImpl.debug(LoggerImpl.kt:131)
```