### PR TITLE
Add support for multiple processes

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,7 +12,7 @@ jobs:
       - name: 'Checkout Repository'
         uses: actions/checkout@v6
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v5
         with:
           config-file: 'ArcGIS/standard-dependency-review-configuration/dependency-review-config.yml@v1'
           external-repo-token: ${{ secrets.SSP_DEPENDENCY_REVIEW_ACCESS_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ order to keep them you will need to add the following to your application progua
 
 * Android SDK 24 or newer.
 
+## Multi-process file logging
+
+`RollingFileAppender` automatically keeps the configured file name for the main app
+process and adds a process suffix for non-main processes. For example, `<file>AppLog</file>` writes
+`AppLog.txt` in the main process and `AppLog_my_process.txt` in a `:my_process` process.
+
 ## Resources
 
 * [GitHub Markdown Reference](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)
@@ -55,4 +61,3 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 A copy of the license is available in the repository's [LICENSE.txt](LICENSE.txt?raw=true) file.
-

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -5,7 +5,8 @@
         <provider
             android:name=".android.ContextProvider"
             android:authorities="${applicationId}.logger-context-installer"
-            android:exported="false" />
+            android:exported="false"
+            android:multiprocess="true" />
     </application>
 
 </manifest>

--- a/src/main/java/com/esri/logger/khronicle/android/AndroidAPIProvider.kt
+++ b/src/main/java/com/esri/logger/khronicle/android/AndroidAPIProvider.kt
@@ -21,6 +21,19 @@ import java.lang.ref.WeakReference
 object AndroidAPIProvider {
   var AppContext: WeakReference<Context?> = WeakReference(null)
 
+  fun installAppContext(context: Context) {
+    AppContext = WeakReference(context.applicationContext)
+  }
+
   val filesDir: File?
     get() = AppContext.get()?.filesDir
+
+  internal fun resolveLogFileName(baseFileName: String): String {
+    val context = AppContext.get() ?: return baseFileName
+    return AndroidProcess.resolveLogFileName(
+        baseFileName = baseFileName,
+        packageName = context.packageName,
+        processName = AndroidProcess.currentProcessName(context),
+    )
+  }
 }

--- a/src/main/java/com/esri/logger/khronicle/android/AndroidAPIProvider.kt
+++ b/src/main/java/com/esri/logger/khronicle/android/AndroidAPIProvider.kt
@@ -14,22 +14,21 @@
 
 package com.esri.logger.khronicle.android
 
-import android.content.Context
+import android.app.Application
 import java.io.File
-import java.lang.ref.WeakReference
 
 object AndroidAPIProvider {
-  var AppContext: WeakReference<Context?> = WeakReference(null)
+  var AppContext: Application? = null
 
-  fun installAppContext(context: Context) {
-    AppContext = WeakReference(context.applicationContext)
+  fun installAppContext(application: Application) {
+    AppContext = application
   }
 
   val filesDir: File?
-    get() = AppContext.get()?.filesDir
+    get() = AppContext?.filesDir
 
   internal fun resolveLogFileName(baseFileName: String): String {
-    val context = AppContext.get() ?: return baseFileName
+    val context = AppContext ?: return baseFileName
     return AndroidProcess.resolveLogFileName(
         baseFileName = baseFileName,
         packageName = context.packageName,

--- a/src/main/java/com/esri/logger/khronicle/android/AndroidProcess.kt
+++ b/src/main/java/com/esri/logger/khronicle/android/AndroidProcess.kt
@@ -1,0 +1,63 @@
+// Copyright 2026 Esri
+//
+// Licensed under the Apache License Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.esri.logger.khronicle.android
+
+import android.app.ActivityManager
+import android.app.Application
+import android.content.Context
+import android.os.Build
+import android.os.Process
+
+internal object AndroidProcess {
+
+  fun resolveLogFileName(baseFileName: String, packageName: String, processName: String?): String {
+    return baseFileName + processSuffix(packageName, processName)
+  }
+
+  fun processSuffix(packageName: String, processName: String?): String {
+    val processFileName =
+        processName
+            ?.takeUnless { it == packageName }
+            ?.removePrefix("$packageName:")
+            ?.sanitizeForFileName()
+            .orEmpty()
+
+    return if (processFileName.isBlank()) "" else "_$processFileName"
+  }
+
+  fun currentProcessName(context: Context): String? {
+    val processNameFromApplication =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+          Application.getProcessName()?.takeIf { it.isNotBlank() }
+        } else {
+          null
+        }
+
+    val currentPid = Process.myPid()
+    val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+    val processNameFromActivityManager =
+        activityManager
+            ?.runningAppProcesses
+            ?.firstOrNull { it.pid == currentPid }
+            ?.processName
+            ?.takeIf { it.isNotBlank() }
+
+    return processNameFromApplication ?: processNameFromActivityManager
+  }
+
+  private fun String.sanitizeForFileName(): String {
+    return replace(Regex("[^A-Za-z0-9._-]"), "_")
+  }
+}

--- a/src/main/java/com/esri/logger/khronicle/android/ContextProvider.kt
+++ b/src/main/java/com/esri/logger/khronicle/android/ContextProvider.kt
@@ -18,12 +18,11 @@ import android.content.ContentProvider
 import android.content.ContentValues
 import android.database.Cursor
 import android.net.Uri
-import java.lang.ref.WeakReference
 
 class ContextProvider : ContentProvider() {
 
   override fun onCreate(): Boolean {
-    AndroidAPIProvider.AppContext = WeakReference(context?.applicationContext)
+    context?.let(AndroidAPIProvider::installAppContext)
     return true
   }
 

--- a/src/main/java/com/esri/logger/khronicle/android/ContextProvider.kt
+++ b/src/main/java/com/esri/logger/khronicle/android/ContextProvider.kt
@@ -14,6 +14,7 @@
 
 package com.esri.logger.khronicle.android
 
+import android.app.Application
 import android.content.ContentProvider
 import android.content.ContentValues
 import android.database.Cursor
@@ -22,7 +23,7 @@ import android.net.Uri
 class ContextProvider : ContentProvider() {
 
   override fun onCreate(): Boolean {
-    context?.let(AndroidAPIProvider::installAppContext)
+    (context?.applicationContext as? Application)?.let(AndroidAPIProvider::installAppContext)
     return true
   }
 

--- a/src/main/java/com/esri/logger/khronicle/appender/RollingFileAppender.kt
+++ b/src/main/java/com/esri/logger/khronicle/appender/RollingFileAppender.kt
@@ -35,16 +35,22 @@ class RollingFileAppender : Appender {
   @JvmField var file: String = FILENAME_DEFAULT
 
   private val bufferedWriter: BufferedWriter by lazy {
-    val appDir = AndroidAPIProvider.filesDir
-    val logDir = File("$appDir/logs")
-    if (!logDir.exists()) {
-      logDir.mkdir()
+    val appDir =
+        requireNotNull(AndroidAPIProvider.filesDir) {
+          "Khronicle app context is unavailable; install it before using file logging."
+        }
+    val logDir = File(appDir, "logs")
+    val resolvedFileName = AndroidAPIProvider.resolveLogFileName(file)
+    if (!logDir.exists() && !logDir.mkdirs()) {
+      error("Could not create Khronicle log directory: $logDir")
     }
 
-    logDir.rotateFilesInPath(file, EXTENSION, MAX_FILES)
+    logDir.rotateFilesInPath(resolvedFileName, EXTENSION, MAX_FILES)
 
-    val logFile = File("${logDir}/$file$EXTENSION")
-    logFile.createNewFile()
+    val logFile = File(logDir, "$resolvedFileName$EXTENSION")
+    if (!logFile.exists() && !logFile.createNewFile()) {
+      error("Could not create Khronicle log file: $logFile")
+    }
     BufferedWriter(FileWriter(logFile))
   }
 

--- a/src/test/java/com/esri/logger/khronicle/ConfigurationParserTest.kt
+++ b/src/test/java/com/esri/logger/khronicle/ConfigurationParserTest.kt
@@ -17,7 +17,6 @@ package com.esri.logger.khronicle
 import com.esri.logger.khronicle.android.AndroidAPIProvider
 import com.esri.logger.khronicle.appender.RollingFileAppender
 import com.esri.logger.khronicle.appender.TestAppender
-import java.lang.ref.WeakReference
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Assert.*
 import org.junit.Test
@@ -178,7 +177,7 @@ class ConfigurationParserTest {
 
   @Test
   fun parse_rollingFileAppenderGetsAddedCorrectly() {
-    AndroidAPIProvider.AppContext = WeakReference(RuntimeEnvironment.getApplication())
+    AndroidAPIProvider.installAppContext(RuntimeEnvironment.getApplication())
 
     val testConfig =
         """

--- a/src/test/java/com/esri/logger/khronicle/android/AndroidAPIProviderTest.kt
+++ b/src/test/java/com/esri/logger/khronicle/android/AndroidAPIProviderTest.kt
@@ -14,7 +14,6 @@
 
 package com.esri.logger.khronicle.android
 
-import java.lang.ref.WeakReference
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -23,7 +22,7 @@ class AndroidAPIProviderTest {
 
   @Before
   fun clearInstalledContext() {
-    AndroidAPIProvider.AppContext = WeakReference(null)
+    AndroidAPIProvider.AppContext = null
   }
 
   @Test

--- a/src/test/java/com/esri/logger/khronicle/android/AndroidAPIProviderTest.kt
+++ b/src/test/java/com/esri/logger/khronicle/android/AndroidAPIProviderTest.kt
@@ -1,0 +1,35 @@
+// Copyright 2026 Esri
+//
+// Licensed under the Apache License Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.esri.logger.khronicle.android
+
+import java.lang.ref.WeakReference
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class AndroidAPIProviderTest {
+
+  @Before
+  fun clearInstalledContext() {
+    AndroidAPIProvider.AppContext = WeakReference(null)
+  }
+
+  @Test
+  fun resolveLogFileName_withoutInstalledContext_returnsBaseFileName() {
+    val fileName = AndroidAPIProvider.resolveLogFileName("ExampleAppLog")
+
+    assertEquals("ExampleAppLog", fileName)
+  }
+}

--- a/src/test/java/com/esri/logger/khronicle/android/AndroidProcessTest.kt
+++ b/src/test/java/com/esri/logger/khronicle/android/AndroidProcessTest.kt
@@ -1,0 +1,93 @@
+// Copyright 2026 Esri
+//
+// Licensed under the Apache License Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.esri.logger.khronicle.android
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AndroidProcessTest {
+
+  @Test
+  fun resolveLogFileName_withMainProcess_keepsBaseFileName() {
+    val fileName =
+        AndroidProcess.resolveLogFileName(
+            baseFileName = "ExampleAppLog",
+            packageName = "com.example.app",
+            processName = "com.example.app",
+        )
+
+    assertEquals("ExampleAppLog", fileName)
+  }
+
+  @Test
+  fun resolveLogFileName_withPackageLocalProcess_addsLocalProcessSuffix() {
+    val fileName =
+        AndroidProcess.resolveLogFileName(
+            baseFileName = "ExampleAppLog",
+            packageName = "com.example.app",
+            processName = "com.example.app:worker",
+        )
+
+    assertEquals("ExampleAppLog_worker", fileName)
+  }
+
+  @Test
+  fun resolveLogFileName_withExternalProcess_addsSanitizedFullProcessSuffix() {
+    val fileName =
+        AndroidProcess.resolveLogFileName(
+            baseFileName = "ExampleAppLog",
+            packageName = "com.example.app",
+            processName = "external/process:name",
+        )
+
+    assertEquals("ExampleAppLog_external_process_name", fileName)
+  }
+
+  @Test
+  fun resolveLogFileName_withBlankProcess_keepsBaseFileName() {
+    val fileName =
+        AndroidProcess.resolveLogFileName(
+            baseFileName = "ExampleAppLog",
+            packageName = "com.example.app",
+            processName = "",
+        )
+
+    assertEquals("ExampleAppLog", fileName)
+  }
+
+  @Test
+  fun resolveLogFileName_withNullProcess_keepsBaseFileName() {
+    val fileName =
+        AndroidProcess.resolveLogFileName(
+            baseFileName = "ExampleAppLog",
+            packageName = "com.example.app",
+            processName = null,
+        )
+
+    assertEquals("ExampleAppLog", fileName)
+  }
+
+  @Test
+  fun resolveLogFileName_withEmptyLocalProcessSuffix_keepsBaseFileName() {
+    val fileName =
+        AndroidProcess.resolveLogFileName(
+            baseFileName = "ExampleAppLog",
+            packageName = "com.example.app",
+            processName = "com.example.app:",
+        )
+
+    assertEquals("ExampleAppLog", fileName)
+  }
+}

--- a/src/test/java/com/esri/logger/khronicle/appender/RollingFileAppenderTest.kt
+++ b/src/test/java/com/esri/logger/khronicle/appender/RollingFileAppenderTest.kt
@@ -18,7 +18,6 @@ import com.esri.logger.khronicle.android.AndroidAPIProvider
 import io.mockk.every
 import io.mockk.mockk
 import java.io.File
-import java.lang.ref.WeakReference
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
@@ -37,19 +36,19 @@ class RollingFileAppenderTest {
 
   @Before
   fun installContextAndCleanLogsDir() {
-    AndroidAPIProvider.AppContext = WeakReference(RuntimeEnvironment.getApplication())
+    AndroidAPIProvider.installAppContext(RuntimeEnvironment.getApplication())
     logsDir = File(RuntimeEnvironment.getApplication().filesDir, "logs")
     logsDir.deleteRecursively()
   }
 
   @After
   fun clearInstalledContext() {
-    AndroidAPIProvider.AppContext = WeakReference(null)
+    AndroidAPIProvider.AppContext = null
   }
 
   @Test
   fun append_withoutInstalledContext_throws() {
-    AndroidAPIProvider.AppContext = WeakReference(null)
+    AndroidAPIProvider.AppContext = null
     val appender = RollingFileAppender().apply { file = "NoContextLog" }
 
     assertThrows(IllegalArgumentException::class.java) { appender.append(loggingEvent("hello")) }

--- a/src/test/java/com/esri/logger/khronicle/appender/RollingFileAppenderTest.kt
+++ b/src/test/java/com/esri/logger/khronicle/appender/RollingFileAppenderTest.kt
@@ -1,0 +1,91 @@
+// Copyright 2026 Esri
+//
+// Licensed under the Apache License Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.esri.logger.khronicle.appender
+
+import com.esri.logger.khronicle.android.AndroidAPIProvider
+import io.mockk.every
+import io.mockk.mockk
+import java.io.File
+import java.lang.ref.WeakReference
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.slf4j.event.LoggingEvent
+
+@RunWith(RobolectricTestRunner::class)
+class RollingFileAppenderTest {
+
+  private lateinit var logsDir: File
+
+  @Before
+  fun installContextAndCleanLogsDir() {
+    AndroidAPIProvider.AppContext = WeakReference(RuntimeEnvironment.getApplication())
+    logsDir = File(RuntimeEnvironment.getApplication().filesDir, "logs")
+    logsDir.deleteRecursively()
+  }
+
+  @After
+  fun clearInstalledContext() {
+    AndroidAPIProvider.AppContext = WeakReference(null)
+  }
+
+  @Test
+  fun append_withoutInstalledContext_throws() {
+    AndroidAPIProvider.AppContext = WeakReference(null)
+    val appender = RollingFileAppender().apply { file = "NoContextLog" }
+
+    assertThrows(IllegalArgumentException::class.java) { appender.append(loggingEvent("hello")) }
+  }
+
+  @Test
+  fun append_inMainProcess_createsLogDirAndBaseFile() {
+    val appender = RollingFileAppender().apply { file = "MainProcessLog" }
+
+    appender.append(loggingEvent("hello"))
+
+    assertTrue("logs directory should be created", logsDir.isDirectory)
+    val logFile = File(logsDir, "MainProcessLog.txt")
+    assertTrue("log file should be created with the base name", logFile.isFile)
+    assertEquals("hello", logFile.readText().trim())
+  }
+
+  @Test
+  fun append_inMainProcess_doesNotAddProcessSuffix() {
+    val appender = RollingFileAppender().apply { file = "NoSuffixLog" }
+
+    appender.append(loggingEvent("first"))
+
+    val unexpectedSuffixed =
+        logsDir.listFiles().orEmpty().filter {
+          it.name.startsWith("NoSuffixLog_") && it.name.endsWith(".txt")
+        }
+    assertTrue(
+        "no per-process suffixed file should be created in the main process",
+        unexpectedSuffixed.isEmpty(),
+    )
+  }
+
+  private fun loggingEvent(message: String): LoggingEvent {
+    val event = mockk<LoggingEvent>()
+    every { event.message } returns message
+    return event
+  }
+}


### PR DESCRIPTION
This adds support for running Khronicle from different processes. The main process keeps logging into the same filename as before (so this is backward compatible), and secondary processes log into files that get the suffix `_<process_name>`.